### PR TITLE
Allow using and passing provider to/as a function in customFilters

### DIFF
--- a/src/OdataProvider.ts
+++ b/src/OdataProvider.ts
@@ -104,7 +104,7 @@ export declare class OdataProviderOptions {
       col: any,
       isCaseSensitiveStringFilter: boolean,
       provider: OdataProvider)=> string
-  }
+  } | ((provider: OdataProvider) => void)
 }
 
 
@@ -1095,4 +1095,4 @@ export class OdataServerSideProvider  extends OdataProvider {
   public override getRows (params: IServerSideGetRowsParams): void {
     super.getRows(params);
   } 
-} 
+}   }


### PR DESCRIPTION
This adds the ability to pass provider to a function in customFilters, and allows using a function on customFilters as well.

I am aware that some settings are lost (like case sensitivity). However I think that for this use case it is acceptable.

I am constructing a string array in backend consisting of the columns that should be using a custom filter (they are all using the same), and instead of needing to type them all out in the front end I can update the string array in the backend and have front end automagically add the correct custom filter.